### PR TITLE
Use HTTPS when downloading jar file

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -15,7 +15,7 @@ import (
 // for automatic testing
 
 const defaultMockFile = "CouchbaseMock-1.5.15.jar"
-const defaultMockUrl = "http://packages.couchbase.com/clients/c/mock/" + defaultMockFile
+const defaultMockUrl = "https://packages.couchbase.com/clients/c/mock/" + defaultMockFile
 
 // Ensures that the mock path is available
 func GetMockPath() (path string, err error) {


### PR DESCRIPTION
Use HTTPS when downloading and running jar file to prevent MITM

## Before

```
2018/05/17 12:13:43 Downloading http://packages.couchbase.com/clients/c/mock/CouchbaseMock-1.5.5.jar to /var/folders/00/8p7hkgx9061b1msn2gmgn9bw0000gn/T/CouchbaseMock-1.5.5.jar
2018/05/17 12:13:44 Listening for control connection at 51580
2018/05/17 12:13:44 Invoking java -jar /var/folders/00/8p7hkgx9061b1msn2gmgn9bw0000gn/T/CouchbaseMock-1.5.5.jar --harakiri-monitor localhost:51580 --port 0 --replicas 1 --vbuckets 64 --nodes 4 --buckets default::couchbase,memd::memcache
```

## After

```
2018/05/17 12:29:14 Downloading https://packages.couchbase.com/clients/c/mock/CouchbaseMock-1.5.15.jar to /var/folders/00/8p7hkgx9061b1msn2gmgn9bw0000gn/T/CouchbaseMock-1.5.15.jar
2018/05/17 12:29:21 Listening for control connection at 51819
2018/05/17 12:29:21 Invoking java -jar /var/folders/00/8p7hkgx9061b1msn2gmgn9bw0000gn/T/CouchbaseMock-1.5.15.jar --harakiri-monitor localhost:51819 --port 0 --replicas 1 --vbuckets 64 --nodes 4 --buckets default::couchbase,memd::memcache
```